### PR TITLE
mxs-dcp: move the dcp device mapper path

### DIFF
--- a/atom.mk
+++ b/atom.mk
@@ -6,6 +6,6 @@ LOCAL_DESTDIR := ./
 LOCAL_MODULE := dm-crypt-dcp
 LOCAL_DESCRIPTION := dm-crypt-dcp module
 
-LOCAL_COPY_FILES := dcp-tool:lib/pv/volmount/dcp-tool
+LOCAL_COPY_FILES := dcp-tool:lib/pv/volmount/crypt/dcp-tool
 
 include $(BUILD_CUSTOM)


### PR DESCRIPTION
include a new device mapper path and re-structure dcp tool
into crypt

Signed-off-by: Parthiban Nallathambi <parthiban.nallathambi@pantacor.com>